### PR TITLE
Use the `nonroot` user by default.

### DIFF
--- a/.apko.yaml
+++ b/.apko.yaml
@@ -4,3 +4,12 @@ contents:
   packages:
     - alpine-baselayout-data
     - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+  run-as: 65532


### PR DESCRIPTION
This makes this image consistent with `gcr.io/distroless/static:nonroot` with respect to the user it runs as.