### PR TITLE
Fan out a vulnz scan against each resulting image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,9 @@ jobs:
     name: Release OCI image
     runs-on: ubuntu-latest
 
+    outputs:
+      image-refs: ${{ steps.emit-refs.outputs.image-refs }}
+
     # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
     permissions:
       id-token: write
@@ -28,13 +31,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - id: apko
       uses: distroless/actions/apko-snapshot@main
       with:
         config: apko.yaml
+        image_refs: apko.images
         base-tag: ghcr.io/${{ github.repository }}
+
     - name: Smoke Test
       run: IMAGE_NAME=${{ steps.apko.outputs.digest }} ./test.sh
+
+    - name: Emit Image Refs output
+      id: emit-refs
+      run: |
+        cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' | jq .
+        echo ::set-output name=image-refs::$(cat apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
 
     # Post to slack when things fail.
     - if: ${{ failure() }}
@@ -49,3 +61,30 @@ jobs:
         SLACK_TITLE: Releasing ${{ github.repository }} failed.
         SLACK_MESSAGE: |
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  scan:
+    name: Scan apko images
+    needs: build
+    runs-on: ubuntu-latest
+
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+
+    strategy:
+      matrix:
+        ref: ${{ fromJson(needs.build.outputs.image-refs) }}
+    steps:
+    - run: |
+        echo ${{ matrix.ref }}
+
+    - uses: distroless/actions/vul-scans@main
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+        image: ${{ matrix.ref }}
+        RUN_SNYK: "false"
+        RUN_GRYPE: "false"


### PR DESCRIPTION
This change takes the resulting `--image-refs` produced by `apko` and runs the vulnerability scan action on each of them.

We shouldn't merge this until https://github.com/distroless/actions/pull/23 lands, and once this lands here, I can draft PRs to the other repos.