### PR TITLE
Fix vulnerability scans for distroless/static

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,6 +81,7 @@ jobs:
         echo ${{ matrix.ref }}
 
     - uses: distroless/actions/vul-scans@main
+      id: scans
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -88,3 +89,35 @@ jobs:
         image: ${{ matrix.ref }}
         RUN_SNYK: "false"
         RUN_GRYPE: "false"
+        DOCKER_LOGIN: 'true'
+
+    - name: Image Vulnerability scan output
+      shell: bash
+      env:
+        SNYK_COUNT: ${{ steps.scans.outputs.SNYK_COUNT }}
+        GRYPE_COUNT: ${{ steps.scans.outputs.GRYPE_COUNT }}
+        TRIVY_COUNT: ${{ steps.scans.outputs.TRIVY_COUNT }}
+      run: |
+        echo "Image Vulnerability scan output" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: ${{ matrix.ref }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Snyk Count: $SNYK_COUNT" >> $GITHUB_STEP_SUMMARY
+        echo "Grype Count: $GRYPE_COUNT" >> $GITHUB_STEP_SUMMARY
+        echo "Trivy Count: $TRIVY_COUNT" >> $GITHUB_STEP_SUMMARY
+
+    - if: ${{ steps.scans.outputs.TRIVY_COUNT != '0' || steps.scans.outputs.GRYPE_COUNT != '0' || steps.scans.outputs.SNYK_COUNT != '0'  }}
+      uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+      env:
+        SLACK_ICON: http://github.com/chainguardian.png?size=48
+        SLACK_USERNAME: chainguardian
+        SLACK_WEBHOOK: ${{ secrets.DISTROLESS_SLACK_WEBHOOK }}
+        SLACK_CHANNEL: distroless-alerts
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'false'
+        SLACK_TITLE: Vulnerability Report for ${{ github.repository }}.
+        SLACK_MESSAGE: |
+          Snyk Count: ${{ steps.scans.outputs.SNYK_COUNT }}
+          Grype Count: ${{ steps.scans.outputs.GRYPE_COUNT }}
+          Trivy Count: ${{ steps.scans.outputs.TRIVY_COUNT }}
+          Image ID: ${{ matrix.ref }}
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

We need `DOCKER_LOGIN: true` or else pushing the vuln attestation fails.

This also adds Slack notifications if vuln scanning fails.

Basically I just copied the [current busybox release.yaml](https://github.com/distroless/busybox/blob/eb4e8d178809ee0f2ebd1be617723e18a83b8260/.github/workflows/release.yaml).