### PR TITLE
Alert when vulnz scanning fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,8 @@ jobs:
       env:
         SLACK_ICON: http://github.com/chainguardian.png?size=48
         SLACK_USERNAME: chainguardian
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_CHANNEL: distroless
+        SLACK_WEBHOOK: ${{ secrets.DISTROLESS_SLACK_WEBHOOK }}
+        SLACK_CHANNEL: distroless-alerts
         SLACK_COLOR: '#8E1600'
         MSG_MINIMAL: 'true'
         SLACK_TITLE: Releasing ${{ github.repository }} failed.
@@ -121,3 +121,18 @@ jobs:
           Trivy Count: ${{ steps.scans.outputs.TRIVY_COUNT }}
           Image ID: ${{ matrix.ref }}
           For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    # Post to slack when things fail.
+    - if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.2.0
+      env:
+        SLACK_ICON: http://github.com/chainguardian.png?size=48
+        SLACK_USERNAME: chainguardian
+        SLACK_WEBHOOK: ${{ secrets.DISTROLESS_SLACK_WEBHOOK }}
+        SLACK_CHANNEL: distroless-alerts
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'true'
+        SLACK_TITLE: Releasing ${{ github.repository }} failed.
+        SLACK_MESSAGE: |
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

If this works out I'll make the same change to all the other repos.

This also uses `DISTROLESS_SLACK_WEBHOOK` when the normal release fails, and posts to `#distroless-alerts`.